### PR TITLE
fix: 회원가입 API 엔드포인트 명칭 정정

### DIFF
--- a/src/main/java/com/hannam/rental/hannam_rental/controller/UserController.java
+++ b/src/main/java/com/hannam/rental/hannam_rental/controller/UserController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 public class UserController {
 
-    @GetMapping("/")
-    public String users() {
+    @GetMapping("/signup")
+    public String signup() {
         return "회원가입";
     }
     @GetMapping("/login")


### PR DESCRIPTION
API 명세서에 회원가입이 users 로 되어있었는데, 회원가입->로그인, 로그아웃 등 여러 엔드포인트로 넘어가는데는 한계가 있다 생각하여 signup으로 명세서 변경 후 코드도 명칭 정정합니다.